### PR TITLE
Fixed react 15.2 warning about Unknown props on DOM

### DIFF
--- a/examples/examples.cjsx
+++ b/examples/examples.cjsx
@@ -46,11 +46,11 @@ module.exports = React.createClass
       {"""
       <RetinaImage
        src="./ocean.jpg"
-       checkIf2xExists=false
+       checkIfRetinaImgExists=false
        width=500 />
         """}
       </code></pre>
-      <RetinaImage src="./ocean.jpg" checkIf2xExists=false width=500 />
+      <RetinaImage src="./ocean.jpg" checkIfRetinaImgExists=false width=500 />
 
       <h3>If you don't have predictable names for the retina and non-retina
       versions of images, you can simply pass in an array of images as src where
@@ -72,17 +72,19 @@ module.exports = React.createClass
       <pre><code>
       {"""
       <RetinaImage
-       src={@state.picsArray[_.random(0,2)]} />
+       style={{width: 500}}
+       onClick={@cyclePics}
+       src={@state.picsArray[@state.picIndex]} />
         """}
       </code></pre>
       <RetinaImage
         style={{width: 500}}
-        onClick={@handleClick}
+        onClick={@cyclePics}
         src={@state.picsArray[@state.picIndex]} />
 
     </div>
 
-  handleClick: ->
+  cyclePics: ->
     newIndex = @state.picIndex + 1
     if newIndex > 2
       newIndex = 0

--- a/examples/index.cjsx
+++ b/examples/index.cjsx
@@ -1,5 +1,10 @@
 React = require 'react'
-ReactDom = require('react-dom')
+ReactDOM = require 'react-dom'
 Examples = require './examples'
 
-ReactDom.render(<Examples />, document.body)
+# Rendering components directly into document.body is discouraged,
+# since its children are often manipulated by third-party scripts and browser extensions.
+# This may lead to subtle reconciliation issues.
+containerEl = document.createElement('DIV')
+document.body.appendChild(containerEl)
+ReactDOM.render(<Examples />, containerEl)

--- a/src/index.cjsx
+++ b/src/index.cjsx
@@ -15,6 +15,7 @@ module.exports = React.createClass
       React.PropTypes.array
     ]).isRequired
     checkIfRetinaImgExists: React.PropTypes.bool
+    forceOriginalDimensions: React.PropTypes.bool
     retinaImageSuffix: React.PropTypes.string
     handleOnLoad: React.PropTypes.func # Deprecated.
     onLoad: React.PropTypes.func
@@ -53,13 +54,31 @@ module.exports = React.createClass
     @checkForRetina()
 
   render: ->
+    # Propagate only the props that `<img>` supports, avoid React `Unknown props` warning. https://fb.me/react-unknown-prop
+    # CoffeeScript does not support splat `...` for object destructuring so using `assign` and `delete`. http://stackoverflow.com/a/20298038
+    imgProps = assign {}, @props
+    delete imgProps.src
+    delete imgProps.checkIfRetinaImgExists
+    delete imgProps.forceOriginalDimensions
+    delete imgProps.retinaImageSuffix
+    delete imgProps.handleOnLoad
+    delete imgProps.onLoad
+    delete imgProps.onError
+
+    # Override some of the props for `<img>`.
+    imgProps.src = @state.src
+    imgProps.onLoad = @handleOnLoad
+    imgProps.onError = @props.onError
+
+    if @state.width >= 0
+      imgProps.width = @state.width
+
+    if @state.height >= 0
+      imgProps.height = @state.height
+
     <img
-      ref="img"
-      {...@props}
-      {...@state}
-      src={@state.src}
-      onError={@props.onError}
-      onLoad={@handleOnLoad} />
+      {...imgProps}
+      ref="img" />
 
   # src can be a href or an array of hrefs.
   wrangleProps: (props=@props) ->


### PR DESCRIPTION
Additionally:
* Fixed propTypes: added missing `forceOriginalDimensions`.
* Fixed examples: `checkIf2xExists` is `checkIfRetinaImgExists`; name
`handleClick` according to its purpose, `cyclePics`; show actual code;
fixed React warning "Rendering components directly into document.body
is discouraged".

Fixes https://github.com/KyleAMathews/react-retina-image/issues/61