### PR TITLE
declare React as a peer dependency only and also allow React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "image-exists": "^1.1.0",
     "is-retina": "^1.0.3",
     "object-assign": "^4.1.0",
-    "prop-types": "^15.5.6",
-    "react": "^15.5.3",
-    "react-dom": "^15.5.3"
+    "prop-types": "^15.5.6"
   },
   "devDependencies": {
     "cjsx-loader": "^3.0.0",
@@ -22,13 +20,16 @@
     "coffee-script": "^1.11.0",
     "css-loader": "^0.25.0",
     "gulp": "^3.9.1",
-    "react": "^15.5.6",
-    "react-dom": "^15.5.6",
-    "react-hot-loader": "^1.2.6",
+    "react": "^15.5.6 || ^16.0.0",
+    "react-dom": "^15.5.6 || ^16.0.0",
     "style-loader": "^0.13.1",
     "underscore": "^1.8.3",
     "webpack": "^1.13.2",
     "webpack-dev-server": "^1.16.1"
+  },
+  "peerDependencies": {
+    "react": "^15.5.6 || ^16.0.0",
+    "react-dom": "^15.5.6 || ^16.0.0"
   },
   "directories": {
     "example": "examples"
@@ -48,6 +49,6 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "watch": "./node_modules/.bin/webpack-dev-server --hot"
+    "watch": "./node_modules/.bin/webpack-dev-server"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,12 +4,10 @@ var webpack = require('webpack');
 module.exports = {
   entry: [
     "webpack-dev-server/client?http://0.0.0.0:8080",
-    'webpack/hot/only-dev-server',
     './examples/index'
   ],
   devServer: {
-    contentBase: './examples/',
-    hot: true
+    contentBase: './examples/'
   },
   devtool: "eval",
   debug: true,
@@ -21,7 +19,6 @@ module.exports = {
     modulesDirectories: ['node_modules']
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin(),
     new webpack.IgnorePlugin(/un~$/)
   ],
@@ -31,7 +28,7 @@ module.exports = {
   module: {
     loaders: [
       { test: /\.css$/, loaders: ['style', 'css']},
-      { test: /\.cjsx$/, loaders: ['react-hot', 'coffee', 'cjsx']},
+      { test: /\.cjsx$/, loaders: ['coffee', 'cjsx']},
       { test: /\.coffee$/, loader: 'coffee' }
     ]
   }


### PR DESCRIPTION
This pull request updates the dependency list to declare React as a peer dependency only (so projects depending on `react-retina-image` can decide freely which version of React they want to pick and ensure that there is only one copy of React in the final bundle).

It also enables `react-retina-image` to be used with React 16 as well as keeping React 15 compatibility.

As a side-effect, I had to disable `react-hot-loader` as the declared version was too outdated to support React 16 and upgrading it to 3.x is outside the scope of this pull request.